### PR TITLE
namespace change & commands > init

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r dev-requirements.txt
       - name: Run tests
-        run: python -m pytest --cov=src/
+        run: python -m pytest --cov=shelf_ready_validator/
       - name: Send report to Coveralls
         uses: AndreMiras/coveralls-python-action@develop
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
-name = "src"
+name = "shelf-ready-validator"
 version = "0.1.0"
 description = ""
 authors = ["Charlotte Kostelic <charlottekostelic@gmail.com>"]
 readme = "README.md"
 
 [tool.setuptools.packages.find]
-where = ["src"]
+where = ["shelf_ready_validator"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
@@ -23,6 +23,9 @@ pytest = "^7.4.3"
 pytest-cov = "^4.1.0"
 mypy = "^1.8.0"
 black = "^23.12.1"
+
+[tool.poetry.scripts]
+validator = "shelf_ready_validator:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ relative_files = true
 source = ["."]
 
 [build-system]
-requires = ["poetry-core", "setuptools"]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]

--- a/run.py
+++ b/run.py
@@ -1,5 +1,0 @@
-from src.commands import cli
-
-
-if __name__ == "__main__":
-    cli()

--- a/shelf_ready_validator/__init__.py
+++ b/shelf_ready_validator/__init__.py
@@ -1,15 +1,15 @@
 import click
-from src.models import MonographRecord, OtherMaterialRecord
-from src.errors import format_error_messages
-from src.translate import (
+from pydantic import ValidationError
+from rich.console import Console
+from rich.theme import Theme
+
+from shelf_ready_validator.models import MonographRecord, OtherMaterialRecord
+from shelf_ready_validator.errors import format_error_messages
+from shelf_ready_validator.translate import (
     read_marc_records,
     get_material_type,
     get_record_input,
 )
-
-from pydantic import ValidationError
-from rich.console import Console
-from rich.theme import Theme
 
 theme = Theme(
     {
@@ -173,3 +173,7 @@ def validate_all(file):
                             )
         console.print("Finished checking records.")
         break
+
+
+def main():
+    cli()

--- a/shelf_ready_validator/errors.py
+++ b/shelf_ready_validator/errors.py
@@ -1,6 +1,7 @@
-from pydantic import ValidationError
-from src.translate import RLMarcEncoding
 from typing import List
+
+from pydantic import ValidationError
+from shelf_ready_validator.translate import RLMarcEncoding
 
 
 def missing_errors(error):

--- a/shelf_ready_validator/models.py
+++ b/shelf_ready_validator/models.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel, Field, ConfigDict, ValidationError, model_validator
 from typing import Literal, Optional, Annotated, Union, List
+
+from pydantic import BaseModel, Field, ConfigDict, ValidationError, model_validator
 from pydantic_core import InitErrorDetails, PydanticCustomError
 
 

--- a/shelf_ready_validator/translate.py
+++ b/shelf_ready_validator/translate.py
@@ -1,5 +1,6 @@
-from bookops_marc import SierraBibReader
 from enum import Enum
+
+from bookops_marc import SierraBibReader
 
 
 class RLMarcEncoding(Enum):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,8 +1,8 @@
 import pytest
 from pydantic import ValidationError
-from src.models import MonographRecord, OtherMaterialRecord
+from shelf_ready_validator.models import MonographRecord, OtherMaterialRecord
 from contextlib import nullcontext as does_not_raise
-from src.errors import (
+from shelf_ready_validator.errors import (
     format_error_messages,
     match_errors,
     item_order_errors,

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 from contextlib import nullcontext as does_not_raise
-from src.models import ItemNYPLRL, ItemNYPLBL, ItemBPL
+from shelf_ready_validator.models import ItemNYPLRL, ItemNYPLBL, ItemBPL
 
 
 def test_call_tag_valid():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 from contextlib import nullcontext as does_not_raise
-from src.models import MonographRecord, OtherMaterialRecord
+from shelf_ready_validator.models import MonographRecord, OtherMaterialRecord
 
 
 def test_monograph_record_valid(valid_rl_monograph_record):

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,4 +1,4 @@
-from src.translate import read_marc_records, get_record_input, get_field_subfield
+from shelf_ready_validator.translate import read_marc_records, get_record_input, get_field_subfield
 from pymarc import Field, Subfield
 import pytest
 


### PR DESCRIPTION
A namespace change and a package folder change to a flat layout to allow a "tool command" type of interface (to drop python run.py ...)

Moved `command.py` code to `shelf_ready_validator.__init__.py`, but that's maybe arbitrary.